### PR TITLE
Add ability to listen on an environment-specified port

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a SMTP docker container for sending emails. You can also relay emails to
 The container accepts `RELAY_NETWORKS` environment variable which *MUST* start with `:` e.g `:192.168.0.0/24` or `:192.168.0.0/24:10.0.0.0/16`.
 The container accepts `KEY_PATH` and `CERTIFICATE_PATH` environment variable that if provided will enable TLS support. The paths must be to the key and certificate file on a exposed volume.  The keys will be copied into the container location.
 The container accepts `MAILNAME` environment variable which will set the outgoing mail hostname
+The container also accepts the `PORT` environment variable, to set the port the mail daemon will listen on inside the container. The default port is `25`.
 
 ## Below are scenarios for using this container
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,8 +19,9 @@ if [ "$KEY_PATH" -a "$CERTIFICATE_PATH" ]; then
 	chmod 640 /etc/exim4/exim.key
 	chmod 640 /etc/exim4/exim.crt
 fi
+
 opts=(
-	dc_local_interfaces '0.0.0.0 ; ::0'
+	dc_local_interfaces "[0.0.0.0]:${PORT:-25} ; [::0]:${PORT:-25}"
 	dc_other_hostnames ''
 	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }')${RELAY_NETWORKS}"
 )


### PR DESCRIPTION
The port defaults to "25" as before, but can be overridden by providing the
PORT environment variable on startup.
