### PR TITLE
regularly run queue operations and retry sending (support greylisting)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN chmod a+x /bin/entrypoint.sh && \
 
 EXPOSE 25
 ENTRYPOINT ["/bin/entrypoint.sh"]
-CMD ["exim", "-bd", "-v"]
+CMD ["exim", "-bd", "-q15m", "-v"]


### PR DESCRIPTION
With your current config, sending mails won't be retried on soft failures ever!
This means if the recipients server is temporary not working, the mail won't be sent. Also, mails to servers with enabled [greylisting](https://en.wikipedia.org/wiki/Greylisting) won't work.

This patch tells exim to run the queue every 15 minutes.
