### PR TITLE
Fix for dc_relay_nets for eth0 with multiple ip addresses

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 opts=(
 	dc_local_interfaces "[0.0.0.0]:${PORT:-25} ; [::0]:${PORT:-25}"
 	dc_other_hostnames ''
-	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }')${RELAY_NETWORKS}"
+	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }' | xargs | sed 's/ /:/g')${RELAY_NETWORKS}"
 )
 
 if [ "$DISABLE_IPV6" ]; then 


### PR DESCRIPTION
For multiple IPs on eth0:

```
    inet 10.0.4.3/24 scope global eth0
       valid_lft forever preferred_lft forever
    inet 10.0.4.2/32 scope global eth0
       valid_lft forever preferred_lft forever
```

this command will format the network addresses: `10.0.4.3/24:10.0.4.2/32`