### PR TITLE
Make SMARTHOST_{ALIASES,USER,PASSWORD} optional

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,15 +46,17 @@ elif [ "$SES_USER" -a "$SES_PASSWORD" ]; then
 # Parameters: SMARTHOST_USER, SMARTHOST_PASSWORD: authentication parameters
 # SMARTHOST_ALIASES: list of aliases to puth auth data for (semicolon separated)
 # SMARTHOST_ADDRESS, SMARTHOST_PORT: connection parameters.
-elif [ "$SMARTHOST_USER" -a "$SMARTHOST_PASSWORD" ] && [ "$SMARTHOST_ALIASES" -a "$SMARTHOST_ADDRESS" ] ; then
+elif [ "$SMARTHOST_ADDRESS" ] ; then
 	opts+=(
 		dc_eximconfig_configtype 'smarthost'
 		dc_smarthost "${SMARTHOST_ADDRESS}::${SMARTHOST_PORT-25}"
 	)
 	rm -f /etc/exim4/passwd.client
-	echo "$SMARTHOST_ALIASES;" | while read -d ";" alias; do
-	  echo "${alias}:$SMARTHOST_USER:$SMARTHOST_PASSWORD" >> /etc/exim4/passwd.client
-	done
+	if [ "$SMARTHOST_ALIASES" -a "$SMARTHOST_USER" -a "$SMARTHOST_PASSWORD" ] ; then
+		echo "$SMARTHOST_ALIASES;" | while read -d ";" alias; do
+			echo "${alias}:$SMARTHOST_USER:$SMARTHOST_PASSWORD" >> /etc/exim4/passwd.client
+		done
+	fi
 elif [ "$RELAY_DOMAINS" ]; then
 	opts+=(
 		dc_relay_domains "${RELAY_DOMAINS}"


### PR DESCRIPTION
I needed to be able to specify the `SMARTHOST_ADDRESS`, but leave the `SMARTHOST_USER`, `SMARTHOST_PASSWORD`, and `SMARTHOST_ALIASES` empty.  This is because the upstream SMTP server (which is out of my control) is filtering on IP address and doesn't permit a username/password to be provided.  This change allows that to happen.  It's working great in my environment.