### PR TITLE
Reinitialize local macros as empty file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Initialize localmacros as an empty file
+echo -n "" > /etc/exim4/exim4.conf.localmacros
+
 if [ "$MAILNAME" ]; then
 	echo "MAIN_HARDCODE_PRIMARY_HOSTNAME = $MAILNAME" > /etc/exim4/exim4.conf.localmacros
 	echo $MAILNAME > /etc/mailname


### PR DESCRIPTION
* Using this docker image with DISABLE_IPV6 environment variable only (small smtp server for development under docker-compose setting) will give an error the second time
you start the container without recreating because it will add an additional disable_ipv6 line to the localmacros file and it gives an error of:
```
2017-07-19 11:06:02 Exim configuration error in line 23 of /var/lib/exim4/config.autogenerated.tmp:
  "disable_ipv6" option set for the second time
```

This fixes it by resetting the localmacros file in the beginning of the entrypoint.