### PR TITLE
added option to override SES port

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You need to set the `GMAIL_USER` and `GMAIL_PASSWORD` to be able to use it.
 ### As Amazon SES Relay
 You need to set the `SES_USER` and `SES_PASSWORD` to be able to use it.<br/>
 You can override the SES region by setting `SES_REGION` as well.
+If you use Google Compute Engine you also should set `SES_PORT` to 2587.
 
 ### As generic SMTP Relay
 You can also use any generic SMTP server with authentication as smarthost.</br>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$GMAIL_USER" -a "$GMAIL_PASSWORD" ]; then
 elif [ "$SES_USER" -a "$SES_PASSWORD" ]; then
 	opts+=(
 		dc_eximconfig_configtype 'smarthost'
-		dc_smarthost "email-smtp.${SES_REGION:=us-east-1}.amazonaws.com::${SES_PORT=587}"
+		dc_smarthost "email-smtp.${SES_REGION:=us-east-1}.amazonaws.com::${SES_PORT:=587}"
 	)
 	echo "*.amazonaws.com:$SES_USER:$SES_PASSWORD" > /etc/exim4/passwd.client
 # Allow to specify an arbitrary smarthost.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$GMAIL_USER" -a "$GMAIL_PASSWORD" ]; then
 elif [ "$SES_USER" -a "$SES_PASSWORD" ]; then
 	opts+=(
 		dc_eximconfig_configtype 'smarthost'
-		dc_smarthost "email-smtp.${SES_REGION:=us-east-1}.amazonaws.com::587"
+		dc_smarthost "email-smtp.${SES_REGION:=us-east-1}.amazonaws.com::${SES_PORT=587}"
 	)
 	echo "*.amazonaws.com:$SES_USER:$SES_PASSWORD" > /etc/exim4/passwd.client
 # Allow to specify an arbitrary smarthost.


### PR DESCRIPTION
Google doesn't allow outbound connections to ports 25 and 587 from GCE instances. Luckly AWS provide the alternative port 2587 to SES. This patch allow one to use the SES_PORT variable to use SES from GCE.