### PR TITLE
Suggestion to add a MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2018 Namshi, https://www.namshi.com/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
*Resolves #34.*

Thanks for making the image :+1: , it helps a lot, but during checking of 3rd party licences we've noticed you haven't specified a licence in your repository. This may mean it cannot be legally used by others, even though by sharing it on GitHub it seems to me you want to let others use it.

**Could you please specify a license, so others can use this repository? It would help a lot!**

I suggest a permissive [MIT license](https://opensource.org/licenses/MIT), under which a lot of open-source is released.
If you don't want to restrict the usage, all it takes from you is just one click now :smile: 

Many thanks.