### PR TITLE
bug #50: upgrade to use debian:stretch as the base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Oluwaseun Obajobi "oluwaseun.obajobi@namshi.com"
 


### PR DESCRIPTION
because the debian:jessie apt mirror we needed has been deprecated.
resolves #50.

as part of submitting this PR, i have:
* verified that the container builds and runs.
* verified that the container sends email as expected.
* verified that it still does the DKIM stuff correctly.
* read over the Exim breaking-changes [release notes](https://github.com/Exim/exim/blob/master/src/README.UPDATING) from versions `4.83` through `4.89` (which is what it installs as of time of writing) and compared against the configuration in the repository for possible issues.

that said, i use this project for rather simple purposes and did not deeply exercise every corner, so if there are any known friction points that i did not look at please let me know and i can take a look.