### PR TITLE
Bug fix on the Google auth

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ if [ "$GMAIL_USER" -a "$GMAIL_PASSWORD" ]; then
 		dc_smarthost 'smtp.gmail.com::587'
 		dc_relay_domains "${RELAY_DOMAINS}"
 	)
-	echo "*.google.com:$GMAIL_USER:$GMAIL_PASSWORD" > /etc/exim4/passwd.client
+	echo "*.gmail.com:$GMAIL_USER:$GMAIL_PASSWORD" > /etc/exim4/passwd.client
 elif [ "$SES_USER" -a "$SES_PASSWORD" ]; then
 	opts+=(
 		dc_eximconfig_configtype 'smarthost'


### PR DESCRIPTION
This fixes #59 

Acutally it's not possible to use Gmail as a relay without this fix