### PR TITLE
add ipv6 addresses to dc_relay_nets

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 opts=(
 	dc_local_interfaces "[${BIND_IP:-0.0.0.0}]:${PORT:-25} ; [${BIND_IP6:-::0}]:${PORT:-25}"
 	dc_other_hostnames "${OTHER_HOSTNAMES}"
-	dc_relay_nets "$(ip addr show dev eth0 | awk '$1 == "inet" { print $2 }' | xargs | sed 's/ /:/g')${RELAY_NETWORKS}"
+	dc_relay_nets "$(ip addr show dev eth0 scope global | awk '$1 == "inet" || $1 == "inet6" { print $2 }' | xargs | sed 's/:/::/g' | sed 's/ /:/g')${RELAY_NETWORKS}"
 )
 
 if [ "$DISABLE_IPV6" ]; then


### PR DESCRIPTION
Previously, this added all connected ipv4 networks to enable relaying for all
direclty connected hosts, but if a host would connect through an ipv6-enabled
network and actually uses an ipv6 connection, relay would suddenly be denied.

This commit also includes all ipv6 addresses, just like ipv4 addresses. Note
that Exim uses : as a separator between entries in this list, so any : inside
the ipv6 address must be doubled.

This also adds `scope global` to the `ip address show` command, to prevent also
picking up link-local addresses. This should not normally affect the ipv4
address, since those are normally global scope anyway.